### PR TITLE
Updated Codes.sh to use yarn instead of Npm

### DIFF
--- a/CODES.sh
+++ b/CODES.sh
@@ -766,14 +766,14 @@ installNpmPackages ()
 
     if runningArch; then
         # sudo $NPM install --python=python$(python2 --version 2>&1 | sed -e 's/Python //g')
-        $NPM install --python=python2 || {
+        yarn install --python=python2 || {
             sudo chown $(whoami) -R "$HOME/.npm"
-            $NPM install --python=python2
+            yarn install --python=python2
         }
     else
-        $NPM install || {
+        yarn install || {
             sudo chown $(whoami) -R "$HOME/.npm"
-            $NPM install
+            yarn install
         }
     fi
 }


### PR DESCRIPTION
I added this since while using Npm with sufficient memory it seemed to cause the CODES.sh program to freeze. I wouldn't receive feedback on what's going on and my cursor in Ubuntu would disappear. Yarn is recommended in the docs (Quick start and Production canvas-lms guides) so I merely swapped them out. The installation finally worked for me following that slight change.